### PR TITLE
Add OpenApi example first name and last name

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,8 +114,10 @@ components:
       properties:
         firstname:
           type: string
+          example: John
         lastname:
           type: string
+          example: Doe
 tags:
 - name: games
   description: Test description for SCC MultiApi Plugin.


### PR DESCRIPTION
The OpenApi example was missing the `example` tag.
The `example` is provided in AsyncApi example, so I raised this for consistency