### PR TITLE
Update recent version in readme from 2.6.1 to 2.7.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ After you have these installed, you need to add the Spring Cloud Contract Maven 
     <dependency>
       <groupId>net.coru</groupId>
       <artifactId>scc-multiapi-converter</artifactId>
-      <version>2.6.1</version>
+      <version>2.7.0</version>
       <scope>compile</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Since the latest version of artifact is 2.7.0, the readme is not having actual artifact version.
https://github.com/corunet/scc-multiapi-converter/releases/tag/2.7.0
