### PR TITLE
point to the right branch and the right repo at checkout action 

### DIFF
--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [ pull_request, issues ]
+on: [ pull_request, pull_request_target, issues ]
 
 jobs:
   greeting:

--- a/.github/workflows/greetings.yml
+++ b/.github/workflows/greetings.yml
@@ -1,6 +1,6 @@
 name: Greetings
 
-on: [ pull_request, pull_request_target, issues ]
+on: [ pull_request, issues ]
 
 jobs:
   greeting:

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -3,7 +3,7 @@ name: Java CI with Maven (PR)
 on:
   pull_request_target:
     branches: [ main ]
-  push:
+  pull_request:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -3,6 +3,8 @@ name: Java CI with Maven (PR)
 on:
   pull_request_target:
     branches: [ main ]
+  pull_request:
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -2,7 +2,7 @@ name: Java CI with Maven (PR)
 
 on:
   pull_request:
-    branches: [ main ]
+    types: [ opened, edited, ready_for_review, review_requested ]
 
 jobs:
   build:
@@ -11,9 +11,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        ref: ${{ github.event.pull_request.head.ref }}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -3,7 +3,7 @@ name: Java CI with Maven (PR)
 on:
   pull_request_target:
     branches: [ main ]
-  pull_request:
+  push:
     branches: [ main ]
 
 jobs:

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -1,9 +1,7 @@
 name: Java CI with Maven (PR)
 
 on:
-  pull_request:
-    branches: [ main ]
-  push:
+  pull_request_target:
     branches: [ main ]
 
 jobs:
@@ -12,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         ref: ${{ github.head_ref }}
     - name: Set up JDK 11

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -2,7 +2,7 @@ name: Java CI with Maven (PR)
 
 on:
   pull_request:
-    types: [ opened, edited, ready_for_review, review_requested ]
+    types: [ opened, synchronize, ready_for_review, review_requested ]
 
 jobs:
   build:

--- a/.github/workflows/maven-pr.yml
+++ b/.github/workflows/maven-pr.yml
@@ -1,8 +1,6 @@
 name: Java CI with Maven (PR)
 
 on:
-  pull_request_target:
-    branches: [ main ]
   pull_request:
     branches: [ main ]
 
@@ -14,7 +12,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: ${{ github.head_ref }}
+        ref: ${{ github.event.pull_request.head.ref }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
     - name: Set up JDK 11
       uses: actions/setup-java@v2
       with:


### PR DESCRIPTION
By changing the event to pull_request_target from pull_request, the head reference points to the last commit even if it's from a fork